### PR TITLE
Refactor/package structure: 패키지구조 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,21 +125,14 @@ sequenceDiagram
 - JPA, jwt ...
 ## 패키지 구조
 ```
-api/
-  <도메인>/ (concert, point, queue)
-    controller.java
+<도메인>/ (concert, point, queue, config...)
+  api/
+    controller/
     request/
     response/
-application/
-  <도메인>/
-    facade.java
-usecase/
-  <도메인>/ 
-domain/
-  <도메인>/ 
+  usecase/
+  domain/
     entity/
-infra/
-  <도메인>/
-common
-  config/
+  infra/
+    
 ```

--- a/src/main/java/com/sparta/hhplusconcert/common/domain/TimeBaseEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/common/domain/TimeBaseEntity.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.domain.common;
+package com.sparta.hhplusconcert.common.domain;
 
 import static lombok.AccessLevel.PROTECTED;
 

--- a/src/main/java/com/sparta/hhplusconcert/concert/api/controller/ConcertController.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/api/controller/ConcertController.java
@@ -2,7 +2,7 @@ package com.sparta.hhplusconcert.concert.api.controller;
 
 import com.sparta.hhplusconcert.concert.api.response.GetConcertDatesResponse;
 import com.sparta.hhplusconcert.concert.api.response.GetConcertSeatsResponse;
-import com.sparta.hhplusconcert.common.config.ApiResponse;
+import com.sparta.hhplusconcert.config.ApiResponse;
 import com.sparta.hhplusconcert.concert.usecase.GetConcertSchedulesService;
 import com.sparta.hhplusconcert.concert.usecase.GetConcertSeatsService;
 import com.sparta.hhplusconcert.concert.usecase.ReserveSeatService;

--- a/src/main/java/com/sparta/hhplusconcert/concert/api/controller/ConcertController.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/api/controller/ConcertController.java
@@ -1,11 +1,11 @@
-package com.sparta.hhplusconcert.api.concert.controller;
+package com.sparta.hhplusconcert.concert.api.controller;
 
-import com.sparta.hhplusconcert.api.concert.response.GetConcertDatesResponse;
-import com.sparta.hhplusconcert.api.concert.response.GetConcertSeatsResponse;
+import com.sparta.hhplusconcert.concert.api.response.GetConcertDatesResponse;
+import com.sparta.hhplusconcert.concert.api.response.GetConcertSeatsResponse;
 import com.sparta.hhplusconcert.common.config.ApiResponse;
-import com.sparta.hhplusconcert.usecase.concert.GetConcertSchedulesService;
-import com.sparta.hhplusconcert.usecase.concert.GetConcertSeatsService;
-import com.sparta.hhplusconcert.usecase.concert.ReserveSeatService;
+import com.sparta.hhplusconcert.concert.usecase.GetConcertSchedulesService;
+import com.sparta.hhplusconcert.concert.usecase.GetConcertSeatsService;
+import com.sparta.hhplusconcert.concert.usecase.ReserveSeatService;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/sparta/hhplusconcert/concert/api/response/GetConcertDatesResponse.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/api/response/GetConcertDatesResponse.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.api.concert.response;
+package com.sparta.hhplusconcert.concert.api.response;
 
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/sparta/hhplusconcert/concert/api/response/GetConcertSeatsResponse.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/api/response/GetConcertSeatsResponse.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.api.concert.response;
+package com.sparta.hhplusconcert.concert.api.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/sparta/hhplusconcert/concert/domain/ConcertScheduler.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/domain/ConcertScheduler.java
@@ -1,9 +1,9 @@
-package com.sparta.hhplusconcert.domain.concert;
+package com.sparta.hhplusconcert.concert.domain;
 
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertReservationEntity;
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertSeatEntity;
-import com.sparta.hhplusconcert.infra.concert.ConcertReservationRepositoryImpl;
-import com.sparta.hhplusconcert.infra.concert.ConcertSeatRepositoryImpl;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertReservationEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertSeatEntity;
+import com.sparta.hhplusconcert.concert.infra.ConcertReservationRepositoryImpl;
+import com.sparta.hhplusconcert.concert.infra.ConcertSeatRepositoryImpl;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/sparta/hhplusconcert/concert/domain/ReservationStatus.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/domain/ReservationStatus.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.domain.concert;
+package com.sparta.hhplusconcert.concert.domain;
 
 public enum ReservationStatus {
   PENDING_PAYMENT,

--- a/src/main/java/com/sparta/hhplusconcert/concert/domain/SeatStatus.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/domain/SeatStatus.java
@@ -1,8 +1,7 @@
-package com.sparta.hhplusconcert.domain.concert;
+package com.sparta.hhplusconcert.concert.domain;
 
 public enum SeatStatus {
   EMPTY,
-
   RESERVED,
   PAID
 }

--- a/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertEntity.java
@@ -1,6 +1,6 @@
 package com.sparta.hhplusconcert.concert.domain.entity;
 
-import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
+import com.sparta.hhplusconcert.common.domain.TimeBaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;

--- a/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertEntity.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.domain.concert.entity;
+package com.sparta.hhplusconcert.concert.domain.entity;
 
 import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertReservationEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertReservationEntity.java
@@ -1,6 +1,6 @@
 package com.sparta.hhplusconcert.concert.domain.entity;
 
-import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
+import com.sparta.hhplusconcert.common.domain.TimeBaseEntity;
 import com.sparta.hhplusconcert.concert.domain.ReservationStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertReservationEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertReservationEntity.java
@@ -1,7 +1,7 @@
-package com.sparta.hhplusconcert.domain.concert.entity;
+package com.sparta.hhplusconcert.concert.domain.entity;
 
 import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
-import com.sparta.hhplusconcert.domain.concert.ReservationStatus;
+import com.sparta.hhplusconcert.concert.domain.ReservationStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertScheduleEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertScheduleEntity.java
@@ -1,30 +1,26 @@
-package com.sparta.hhplusconcert.domain.concert.entity;
+package com.sparta.hhplusconcert.concert.domain.entity;
 
 import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
-import com.sparta.hhplusconcert.domain.concert.SeatStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
-@Table(name = "CONCERT_SEAT")
+@Table(name = "CONCERT_SCHEDULE")
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class ConcertSeatEntity extends TimeBaseEntity {
+public class ConcertScheduleEntity extends TimeBaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
@@ -33,12 +29,11 @@ public class ConcertSeatEntity extends TimeBaseEntity {
   private Long concertId;
 
   @Column(nullable = false)
-  private Long scheduleId;
+  private LocalDate date;
+
+  private Integer seatCapacity = 50;
 
   @Column(nullable = false)
-  private Integer seatNumber;
-
-  @Enumerated(EnumType.STRING)
-  private SeatStatus status;
+  private Integer seatLeft;
 
 }

--- a/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertScheduleEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertScheduleEntity.java
@@ -1,6 +1,6 @@
 package com.sparta.hhplusconcert.concert.domain.entity;
 
-import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
+import com.sparta.hhplusconcert.common.domain.TimeBaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertSeatEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertSeatEntity.java
@@ -1,6 +1,6 @@
 package com.sparta.hhplusconcert.concert.domain.entity;
 
-import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
+import com.sparta.hhplusconcert.common.domain.TimeBaseEntity;
 import com.sparta.hhplusconcert.concert.domain.SeatStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertSeatEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/domain/entity/ConcertSeatEntity.java
@@ -1,26 +1,30 @@
-package com.sparta.hhplusconcert.domain.concert.entity;
+package com.sparta.hhplusconcert.concert.domain.entity;
 
 import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
+import com.sparta.hhplusconcert.concert.domain.SeatStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
-@Table(name = "CONCERT_SCHEDULE")
+@Table(name = "CONCERT_SEAT")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class ConcertScheduleEntity extends TimeBaseEntity {
+public class ConcertSeatEntity extends TimeBaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
@@ -29,11 +33,12 @@ public class ConcertScheduleEntity extends TimeBaseEntity {
   private Long concertId;
 
   @Column(nullable = false)
-  private LocalDate date;
-
-  private Integer seatCapacity = 50;
+  private Long scheduleId;
 
   @Column(nullable = false)
-  private Integer seatLeft;
+  private Integer seatNumber;
+
+  @Enumerated(EnumType.STRING)
+  private SeatStatus status;
 
 }

--- a/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertReservationJpaRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertReservationJpaRepository.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.concert;
+package com.sparta.hhplusconcert.concert.infra;
 
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertReservationEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertReservationEntity;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertReservationRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertReservationRepository.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.concert;
+package com.sparta.hhplusconcert.concert.infra;
 
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertReservationEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertReservationEntity;
 import java.time.LocalDateTime;
 import java.util.List;
 

--- a/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertReservationRepositoryImpl.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertReservationRepositoryImpl.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.concert;
+package com.sparta.hhplusconcert.concert.infra;
 
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertReservationEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertReservationEntity;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;

--- a/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertScheduleJpaRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertScheduleJpaRepository.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.concert;
+package com.sparta.hhplusconcert.concert.infra;
 
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertScheduleEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertScheduleEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertScheduleRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertScheduleRepository.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.concert;
+package com.sparta.hhplusconcert.concert.infra;
 
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertScheduleEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertScheduleEntity;
 import java.util.List;
 
 public interface ConcertScheduleRepository {

--- a/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertScheduleRepositoryImpl.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertScheduleRepositoryImpl.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.concert;
+package com.sparta.hhplusconcert.concert.infra;
 
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertScheduleEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertScheduleEntity;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertSeatJpaRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertSeatJpaRepository.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.concert;
+package com.sparta.hhplusconcert.concert.infra;
 
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertSeatEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertSeatEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertSeatRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertSeatRepository.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.concert;
+package com.sparta.hhplusconcert.concert.infra;
 
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertSeatEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertSeatEntity;
 import java.util.List;
 
 public interface ConcertSeatRepository {

--- a/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertSeatRepositoryImpl.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/infra/ConcertSeatRepositoryImpl.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.concert;
+package com.sparta.hhplusconcert.concert.infra;
 
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertSeatEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertSeatEntity;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.LockModeType;
 import java.util.List;

--- a/src/main/java/com/sparta/hhplusconcert/concert/usecase/GetConcertSchedulesService.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/usecase/GetConcertSchedulesService.java
@@ -1,7 +1,7 @@
-package com.sparta.hhplusconcert.usecase.concert;
+package com.sparta.hhplusconcert.concert.usecase;
 
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertScheduleEntity;
-import com.sparta.hhplusconcert.infra.concert.ConcertScheduleRepositoryImpl;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertScheduleEntity;
+import com.sparta.hhplusconcert.concert.infra.ConcertScheduleRepositoryImpl;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/sparta/hhplusconcert/concert/usecase/GetConcertSeatsService.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/usecase/GetConcertSeatsService.java
@@ -1,8 +1,8 @@
-package com.sparta.hhplusconcert.usecase.concert;
+package com.sparta.hhplusconcert.concert.usecase;
 
-import com.sparta.hhplusconcert.domain.concert.SeatStatus;
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertSeatEntity;
-import com.sparta.hhplusconcert.infra.concert.ConcertSeatRepositoryImpl;
+import com.sparta.hhplusconcert.concert.domain.SeatStatus;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertSeatEntity;
+import com.sparta.hhplusconcert.concert.infra.ConcertSeatRepositoryImpl;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Builder;

--- a/src/main/java/com/sparta/hhplusconcert/concert/usecase/ReserveSeatService.java
+++ b/src/main/java/com/sparta/hhplusconcert/concert/usecase/ReserveSeatService.java
@@ -1,11 +1,11 @@
-package com.sparta.hhplusconcert.usecase.concert;
+package com.sparta.hhplusconcert.concert.usecase;
 
-import com.sparta.hhplusconcert.domain.concert.ReservationStatus;
-import com.sparta.hhplusconcert.domain.concert.SeatStatus;
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertReservationEntity;
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertSeatEntity;
-import com.sparta.hhplusconcert.infra.concert.ConcertReservationRepositoryImpl;
-import com.sparta.hhplusconcert.infra.concert.ConcertSeatRepositoryImpl;
+import com.sparta.hhplusconcert.concert.domain.ReservationStatus;
+import com.sparta.hhplusconcert.concert.domain.SeatStatus;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertReservationEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertSeatEntity;
+import com.sparta.hhplusconcert.concert.infra.ConcertReservationRepositoryImpl;
+import com.sparta.hhplusconcert.concert.infra.ConcertSeatRepositoryImpl;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/sparta/hhplusconcert/config/ApiResponse.java
+++ b/src/main/java/com/sparta/hhplusconcert/config/ApiResponse.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.common.config;
+package com.sparta.hhplusconcert.config;
 
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.FOUND;

--- a/src/main/java/com/sparta/hhplusconcert/config/SchedulingConfig.java
+++ b/src/main/java/com/sparta/hhplusconcert/config/SchedulingConfig.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.common.config;
+package com.sparta.hhplusconcert.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;

--- a/src/main/java/com/sparta/hhplusconcert/config/SwaggerConfig.java
+++ b/src/main/java/com/sparta/hhplusconcert/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.common.config;
+package com.sparta.hhplusconcert.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/src/main/java/com/sparta/hhplusconcert/infra/point/PaymentRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/infra/point/PaymentRepository.java
@@ -1,9 +1,0 @@
-package com.sparta.hhplusconcert.infra.point;
-
-import com.sparta.hhplusconcert.domain.point.entity.PaymentEntity;
-
-public interface PaymentRepository {
-
-  Long generatePayment(PaymentEntity payment);
-
-}

--- a/src/main/java/com/sparta/hhplusconcert/infra/point/PointHistoryRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/infra/point/PointHistoryRepository.java
@@ -1,7 +1,0 @@
-package com.sparta.hhplusconcert.infra.point;
-
-import com.sparta.hhplusconcert.domain.point.entity.PointHistoryEntity;
-
-public interface PointHistoryRepository {
-  Long chargePoint(PointHistoryEntity pointHistory);
-}

--- a/src/main/java/com/sparta/hhplusconcert/point/api/controller/PointController.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/api/controller/PointController.java
@@ -1,11 +1,11 @@
-package com.sparta.hhplusconcert.api.point.controller;
+package com.sparta.hhplusconcert.point.api.controller;
 
-import com.sparta.hhplusconcert.api.point.request.PaySeatRequest;
-import com.sparta.hhplusconcert.api.point.request.ChargePointRequest;
+import com.sparta.hhplusconcert.point.api.request.PaySeatRequest;
+import com.sparta.hhplusconcert.point.api.request.ChargePointRequest;
 import com.sparta.hhplusconcert.common.config.ApiResponse;
-import com.sparta.hhplusconcert.usecase.point.ChargePointService;
-import com.sparta.hhplusconcert.usecase.point.GetPointService;
-import com.sparta.hhplusconcert.usecase.point.PaySeatService;
+import com.sparta.hhplusconcert.point.usecase.ChargePointService;
+import com.sparta.hhplusconcert.point.usecase.GetPointService;
+import com.sparta.hhplusconcert.point.usecase.PaySeatService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/sparta/hhplusconcert/point/api/controller/PointController.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/api/controller/PointController.java
@@ -2,7 +2,7 @@ package com.sparta.hhplusconcert.point.api.controller;
 
 import com.sparta.hhplusconcert.point.api.request.PaySeatRequest;
 import com.sparta.hhplusconcert.point.api.request.ChargePointRequest;
-import com.sparta.hhplusconcert.common.config.ApiResponse;
+import com.sparta.hhplusconcert.config.ApiResponse;
 import com.sparta.hhplusconcert.point.usecase.ChargePointService;
 import com.sparta.hhplusconcert.point.usecase.GetPointService;
 import com.sparta.hhplusconcert.point.usecase.PaySeatService;

--- a/src/main/java/com/sparta/hhplusconcert/point/api/request/ChargePointRequest.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/api/request/ChargePointRequest.java
@@ -1,6 +1,5 @@
-package com.sparta.hhplusconcert.domain.point;
+package com.sparta.hhplusconcert.point.api.request;
 
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,12 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class User {
-
-  private Long id;
-
-  private UUID userUuid;
-
-  private Long point;
-
+public class ChargePointRequest {
+  private Long userId;
+  private Long amount;
 }

--- a/src/main/java/com/sparta/hhplusconcert/point/api/request/PaySeatRequest.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/api/request/PaySeatRequest.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.api.point.request;
+package com.sparta.hhplusconcert.point.api.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/sparta/hhplusconcert/point/domain/PointTransactionType.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/domain/PointTransactionType.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.domain.point;
+package com.sparta.hhplusconcert.point.domain;
 
 public enum PointTransactionType {
   CHARGE,

--- a/src/main/java/com/sparta/hhplusconcert/point/domain/User.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/domain/User.java
@@ -1,5 +1,6 @@
-package com.sparta.hhplusconcert.api.point.request;
+package com.sparta.hhplusconcert.point.domain;
 
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,7 +10,12 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChargePointRequest {
-  private Long userId;
-  private Long amount;
+public class User {
+
+  private Long id;
+
+  private UUID userUuid;
+
+  private Long point;
+
 }

--- a/src/main/java/com/sparta/hhplusconcert/point/domain/entity/PaymentEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/domain/entity/PaymentEntity.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.domain.point.entity;
+package com.sparta.hhplusconcert.point.domain.entity;
 
 import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
 import jakarta.persistence.Column;

--- a/src/main/java/com/sparta/hhplusconcert/point/domain/entity/PaymentEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/domain/entity/PaymentEntity.java
@@ -1,6 +1,6 @@
 package com.sparta.hhplusconcert.point.domain.entity;
 
-import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
+import com.sparta.hhplusconcert.common.domain.TimeBaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/sparta/hhplusconcert/point/domain/entity/PointHistoryEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/domain/entity/PointHistoryEntity.java
@@ -1,7 +1,7 @@
-package com.sparta.hhplusconcert.domain.point.entity;
+package com.sparta.hhplusconcert.point.domain.entity;
 
 import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
-import com.sparta.hhplusconcert.domain.point.PointTransactionType;
+import com.sparta.hhplusconcert.point.domain.PointTransactionType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/sparta/hhplusconcert/point/domain/entity/PointHistoryEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/domain/entity/PointHistoryEntity.java
@@ -1,6 +1,6 @@
 package com.sparta.hhplusconcert.point.domain.entity;
 
-import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
+import com.sparta.hhplusconcert.common.domain.TimeBaseEntity;
 import com.sparta.hhplusconcert.point.domain.PointTransactionType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/sparta/hhplusconcert/point/domain/entity/UserEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/domain/entity/UserEntity.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.domain.point.entity;
+package com.sparta.hhplusconcert.point.domain.entity;
 
 import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
 import jakarta.persistence.Column;

--- a/src/main/java/com/sparta/hhplusconcert/point/domain/entity/UserEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/domain/entity/UserEntity.java
@@ -1,6 +1,6 @@
 package com.sparta.hhplusconcert.point.domain.entity;
 
-import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
+import com.sparta.hhplusconcert.common.domain.TimeBaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/sparta/hhplusconcert/point/infra/PaymentJpaRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/infra/PaymentJpaRepository.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.point;
+package com.sparta.hhplusconcert.point.infra;
 
-import com.sparta.hhplusconcert.domain.point.entity.PaymentEntity;
+import com.sparta.hhplusconcert.point.domain.entity.PaymentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentJpaRepository extends JpaRepository<PaymentEntity, Long> {

--- a/src/main/java/com/sparta/hhplusconcert/point/infra/PaymentRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/infra/PaymentRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.hhplusconcert.point.infra;
+
+import com.sparta.hhplusconcert.point.domain.entity.PaymentEntity;
+
+public interface PaymentRepository {
+
+  Long generatePayment(PaymentEntity payment);
+
+}

--- a/src/main/java/com/sparta/hhplusconcert/point/infra/PaymentRepositoryImpl.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/infra/PaymentRepositoryImpl.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.point;
+package com.sparta.hhplusconcert.point.infra;
 
-import com.sparta.hhplusconcert.domain.point.entity.PaymentEntity;
+import com.sparta.hhplusconcert.point.domain.entity.PaymentEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/sparta/hhplusconcert/point/infra/PointHistoryJpaRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/infra/PointHistoryJpaRepository.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.point;
+package com.sparta.hhplusconcert.point.infra;
 
-import com.sparta.hhplusconcert.domain.point.entity.PointHistoryEntity;
+import com.sparta.hhplusconcert.point.domain.entity.PointHistoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PointHistoryJpaRepository extends JpaRepository<PointHistoryEntity,Long> {

--- a/src/main/java/com/sparta/hhplusconcert/point/infra/PointHistoryRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/infra/PointHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.hhplusconcert.point.infra;
+
+import com.sparta.hhplusconcert.point.domain.entity.PointHistoryEntity;
+
+public interface PointHistoryRepository {
+  Long chargePoint(PointHistoryEntity pointHistory);
+}

--- a/src/main/java/com/sparta/hhplusconcert/point/infra/PointHistoryRepositoryImpl.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/infra/PointHistoryRepositoryImpl.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.point;
+package com.sparta.hhplusconcert.point.infra;
 
-import com.sparta.hhplusconcert.domain.point.entity.PointHistoryEntity;
+import com.sparta.hhplusconcert.point.domain.entity.PointHistoryEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/sparta/hhplusconcert/point/infra/UserJpaRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/infra/UserJpaRepository.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.point;
+package com.sparta.hhplusconcert.point.infra;
 
-import com.sparta.hhplusconcert.domain.point.entity.UserEntity;
+import com.sparta.hhplusconcert.point.domain.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {

--- a/src/main/java/com/sparta/hhplusconcert/point/infra/UserRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/infra/UserRepository.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.point;
+package com.sparta.hhplusconcert.point.infra;
 
-import com.sparta.hhplusconcert.domain.point.entity.UserEntity;
+import com.sparta.hhplusconcert.point.domain.entity.UserEntity;
 
 public interface UserRepository {
   UserEntity getUserData(Long id);

--- a/src/main/java/com/sparta/hhplusconcert/point/infra/UserRepositoryImpl.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/infra/UserRepositoryImpl.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.infra.point;
+package com.sparta.hhplusconcert.point.infra;
 
-import com.sparta.hhplusconcert.domain.point.entity.UserEntity;
+import com.sparta.hhplusconcert.point.domain.entity.UserEntity;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/sparta/hhplusconcert/point/usecase/ChargePointService.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/usecase/ChargePointService.java
@@ -1,10 +1,10 @@
-package com.sparta.hhplusconcert.usecase.point;
+package com.sparta.hhplusconcert.point.usecase;
 
-import com.sparta.hhplusconcert.domain.point.PointTransactionType;
-import com.sparta.hhplusconcert.domain.point.entity.PointHistoryEntity;
-import com.sparta.hhplusconcert.domain.point.entity.UserEntity;
-import com.sparta.hhplusconcert.infra.point.PointHistoryRepositoryImpl;
-import com.sparta.hhplusconcert.infra.point.UserRepositoryImpl;
+import com.sparta.hhplusconcert.point.domain.PointTransactionType;
+import com.sparta.hhplusconcert.point.domain.entity.PointHistoryEntity;
+import com.sparta.hhplusconcert.point.domain.entity.UserEntity;
+import com.sparta.hhplusconcert.point.infra.PointHistoryRepositoryImpl;
+import com.sparta.hhplusconcert.point.infra.UserRepositoryImpl;
 import jakarta.transaction.Transactional;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/sparta/hhplusconcert/point/usecase/GetPointService.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/usecase/GetPointService.java
@@ -1,6 +1,6 @@
-package com.sparta.hhplusconcert.usecase.point;
+package com.sparta.hhplusconcert.point.usecase;
 
-import com.sparta.hhplusconcert.infra.point.UserRepositoryImpl;
+import com.sparta.hhplusconcert.point.infra.UserRepositoryImpl;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;

--- a/src/main/java/com/sparta/hhplusconcert/point/usecase/PaySeatService.java
+++ b/src/main/java/com/sparta/hhplusconcert/point/usecase/PaySeatService.java
@@ -1,18 +1,18 @@
-package com.sparta.hhplusconcert.usecase.point;
+package com.sparta.hhplusconcert.point.usecase;
 
 import com.sparta.hhplusconcert.concert.domain.ReservationStatus;
 import com.sparta.hhplusconcert.concert.domain.SeatStatus;
 import com.sparta.hhplusconcert.concert.domain.entity.ConcertReservationEntity;
 import com.sparta.hhplusconcert.concert.domain.entity.ConcertSeatEntity;
-import com.sparta.hhplusconcert.domain.point.PointTransactionType;
-import com.sparta.hhplusconcert.domain.point.entity.PaymentEntity;
-import com.sparta.hhplusconcert.domain.point.entity.PointHistoryEntity;
-import com.sparta.hhplusconcert.domain.point.entity.UserEntity;
+import com.sparta.hhplusconcert.point.domain.PointTransactionType;
+import com.sparta.hhplusconcert.point.domain.entity.PaymentEntity;
+import com.sparta.hhplusconcert.point.domain.entity.PointHistoryEntity;
+import com.sparta.hhplusconcert.point.domain.entity.UserEntity;
 import com.sparta.hhplusconcert.concert.infra.ConcertReservationRepositoryImpl;
 import com.sparta.hhplusconcert.concert.infra.ConcertSeatRepositoryImpl;
-import com.sparta.hhplusconcert.infra.point.PaymentRepositoryImpl;
-import com.sparta.hhplusconcert.infra.point.PointHistoryRepositoryImpl;
-import com.sparta.hhplusconcert.infra.point.UserRepositoryImpl;
+import com.sparta.hhplusconcert.point.infra.PaymentRepositoryImpl;
+import com.sparta.hhplusconcert.point.infra.PointHistoryRepositoryImpl;
+import com.sparta.hhplusconcert.point.infra.UserRepositoryImpl;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import lombok.Builder;

--- a/src/main/java/com/sparta/hhplusconcert/queue/api/controller/QueueController.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/api/controller/QueueController.java
@@ -1,7 +1,7 @@
 package com.sparta.hhplusconcert.queue.api.controller;
 
 import com.sparta.hhplusconcert.queue.api.response.CreateQueueResponse;
-import com.sparta.hhplusconcert.common.config.ApiResponse;
+import com.sparta.hhplusconcert.config.ApiResponse;
 import com.sparta.hhplusconcert.queue.usecase.CreateJWTQueueTokenService;
 import com.sparta.hhplusconcert.queue.usecase.CreateJWTQueueTokenService.Input;
 import com.sparta.hhplusconcert.queue.usecase.GetRemainingQueueService;

--- a/src/main/java/com/sparta/hhplusconcert/queue/api/controller/QueueController.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/api/controller/QueueController.java
@@ -1,10 +1,10 @@
-package com.sparta.hhplusconcert.api.queue.controller;
+package com.sparta.hhplusconcert.queue.api.controller;
 
-import com.sparta.hhplusconcert.api.queue.response.CreateQueueResponse;
+import com.sparta.hhplusconcert.queue.api.response.CreateQueueResponse;
 import com.sparta.hhplusconcert.common.config.ApiResponse;
-import com.sparta.hhplusconcert.usecase.queue.CreateJWTQueueTokenService;
-import com.sparta.hhplusconcert.usecase.queue.CreateJWTQueueTokenService.Input;
-import com.sparta.hhplusconcert.usecase.queue.GetRemainingQueueService;
+import com.sparta.hhplusconcert.queue.usecase.CreateJWTQueueTokenService;
+import com.sparta.hhplusconcert.queue.usecase.CreateJWTQueueTokenService.Input;
+import com.sparta.hhplusconcert.queue.usecase.GetRemainingQueueService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,9 +21,9 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public class QueueController {
   private final CreateJWTQueueTokenService createJWTQueueTokenService;
   private final GetRemainingQueueService getRemainingQueueService;
-  @PostMapping("/token")
+  @PostMapping("/token/generate")
   public ApiResponse<CreateQueueResponse> createQueue(
-      @RequestHeader("X-Uesr-UUID") UUID userUuid
+      @RequestHeader("X-USER-UUID") UUID userUuid
   ) {
     log.debug("QueueController#createQueue called.");
     log.debug("userUuid={}", userUuid);
@@ -42,8 +42,8 @@ public class QueueController {
 
   @GetMapping("/token")
   public ApiResponse<Integer> checkQueuePosition(
-      @RequestHeader("X-User-UUID") UUID userUuid
-      , @RequestHeader("X-Queue-Token") String token
+      @RequestHeader("X-USER-UUID") UUID userUuid
+      , @RequestHeader("X-QUEUE-TOKEN") String token
   ) {
     log.debug("QueueController#checkQueuePosition called.");
     log.debug("userUuid={}", userUuid);

--- a/src/main/java/com/sparta/hhplusconcert/queue/api/response/CreateQueueResponse.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/api/response/CreateQueueResponse.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.api.queue.response;
+package com.sparta.hhplusconcert.queue.api.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/sparta/hhplusconcert/queue/domain/ExpiredTokenException.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/domain/ExpiredTokenException.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.domain.queue;
+package com.sparta.hhplusconcert.queue.domain;
 
 public class ExpiredTokenException extends RuntimeException {
   public ExpiredTokenException(String message) {

--- a/src/main/java/com/sparta/hhplusconcert/queue/domain/InvalidTokenException.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/domain/InvalidTokenException.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.domain.queue;
+package com.sparta.hhplusconcert.queue.domain;
 
 public class InvalidTokenException extends RuntimeException{
   public InvalidTokenException(String message) {

--- a/src/main/java/com/sparta/hhplusconcert/queue/domain/QueueToken.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/domain/QueueToken.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.domain.queue;
+package com.sparta.hhplusconcert.queue.domain;
 
 import com.sparta.hhplusconcert.domain.common.Status;
 import java.time.LocalDateTime;

--- a/src/main/java/com/sparta/hhplusconcert/queue/domain/QueueToken.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/domain/QueueToken.java
@@ -1,6 +1,5 @@
 package com.sparta.hhplusconcert.queue.domain;
 
-import com.sparta.hhplusconcert.domain.common.Status;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;

--- a/src/main/java/com/sparta/hhplusconcert/queue/domain/QueueTokenScheduler.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/domain/QueueTokenScheduler.java
@@ -1,6 +1,5 @@
 package com.sparta.hhplusconcert.queue.domain;
 
-import com.sparta.hhplusconcert.domain.common.Status;
 import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
 import com.sparta.hhplusconcert.queue.infra.QueueTokenRepositoryImpl;
 import jakarta.transaction.Transactional;

--- a/src/main/java/com/sparta/hhplusconcert/queue/domain/QueueTokenScheduler.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/domain/QueueTokenScheduler.java
@@ -1,8 +1,8 @@
-package com.sparta.hhplusconcert.domain.queue;
+package com.sparta.hhplusconcert.queue.domain;
 
 import com.sparta.hhplusconcert.domain.common.Status;
-import com.sparta.hhplusconcert.domain.queue.entity.QueueTokenEntity;
-import com.sparta.hhplusconcert.infra.queue.QueueTokenRepositoryImpl;
+import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
+import com.sparta.hhplusconcert.queue.infra.QueueTokenRepositoryImpl;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/sparta/hhplusconcert/queue/domain/Status.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/domain/Status.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.domain.common;
+package com.sparta.hhplusconcert.queue.domain;
 
 import lombok.Getter;
 

--- a/src/main/java/com/sparta/hhplusconcert/queue/domain/TokenValidator.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/domain/TokenValidator.java
@@ -1,7 +1,7 @@
-package com.sparta.hhplusconcert.domain.queue;
+package com.sparta.hhplusconcert.queue.domain;
 
-import com.sparta.hhplusconcert.domain.queue.entity.QueueTokenEntity;
-import com.sparta.hhplusconcert.infra.queue.QueueTokenRepositoryImpl;
+import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
+import com.sparta.hhplusconcert.queue.infra.QueueTokenRepositoryImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/sparta/hhplusconcert/queue/domain/entity/QueueTokenEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/domain/entity/QueueTokenEntity.java
@@ -1,7 +1,7 @@
 package com.sparta.hhplusconcert.queue.domain.entity;
 
-import com.sparta.hhplusconcert.domain.common.Status;
-import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;
+import com.sparta.hhplusconcert.queue.domain.Status;
+import com.sparta.hhplusconcert.common.domain.TimeBaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/sparta/hhplusconcert/queue/domain/entity/QueueTokenEntity.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/domain/entity/QueueTokenEntity.java
@@ -1,4 +1,4 @@
-package com.sparta.hhplusconcert.domain.queue.entity;
+package com.sparta.hhplusconcert.queue.domain.entity;
 
 import com.sparta.hhplusconcert.domain.common.Status;
 import com.sparta.hhplusconcert.domain.common.TimeBaseEntity;

--- a/src/main/java/com/sparta/hhplusconcert/queue/infra/QueueTokenJpaRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/infra/QueueTokenJpaRepository.java
@@ -1,7 +1,7 @@
-package com.sparta.hhplusconcert.infra.queue;
+package com.sparta.hhplusconcert.queue.infra;
 
 import com.sparta.hhplusconcert.domain.common.Status;
-import com.sparta.hhplusconcert.domain.queue.entity.QueueTokenEntity;
+import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/sparta/hhplusconcert/queue/infra/QueueTokenJpaRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/infra/QueueTokenJpaRepository.java
@@ -1,6 +1,6 @@
 package com.sparta.hhplusconcert.queue.infra;
 
-import com.sparta.hhplusconcert.domain.common.Status;
+import com.sparta.hhplusconcert.queue.domain.Status;
 import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;

--- a/src/main/java/com/sparta/hhplusconcert/queue/infra/QueueTokenRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/infra/QueueTokenRepository.java
@@ -1,7 +1,7 @@
-package com.sparta.hhplusconcert.infra.queue;
+package com.sparta.hhplusconcert.queue.infra;
 
 import com.sparta.hhplusconcert.domain.common.Status;
-import com.sparta.hhplusconcert.domain.queue.entity.QueueTokenEntity;
+import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/sparta/hhplusconcert/queue/infra/QueueTokenRepository.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/infra/QueueTokenRepository.java
@@ -1,6 +1,6 @@
 package com.sparta.hhplusconcert.queue.infra;
 
-import com.sparta.hhplusconcert.domain.common.Status;
+import com.sparta.hhplusconcert.queue.domain.Status;
 import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/sparta/hhplusconcert/queue/infra/QueueTokenRepositoryImpl.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/infra/QueueTokenRepositoryImpl.java
@@ -1,7 +1,7 @@
-package com.sparta.hhplusconcert.infra.queue;
+package com.sparta.hhplusconcert.queue.infra;
 
 import com.sparta.hhplusconcert.domain.common.Status;
-import com.sparta.hhplusconcert.domain.queue.entity.QueueTokenEntity;
+import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
 import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/sparta/hhplusconcert/queue/infra/QueueTokenRepositoryImpl.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/infra/QueueTokenRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.sparta.hhplusconcert.queue.infra;
 
-import com.sparta.hhplusconcert.domain.common.Status;
+import com.sparta.hhplusconcert.queue.domain.Status;
 import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
 import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;

--- a/src/main/java/com/sparta/hhplusconcert/queue/usecase/CreateJWTQueueTokenService.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/usecase/CreateJWTQueueTokenService.java
@@ -1,7 +1,7 @@
 package com.sparta.hhplusconcert.queue.usecase;
 
 
-import com.sparta.hhplusconcert.domain.common.Status;
+import com.sparta.hhplusconcert.queue.domain.Status;
 import com.sparta.hhplusconcert.queue.domain.QueueTokenScheduler;
 import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
 import com.sparta.hhplusconcert.queue.infra.QueueTokenRepositoryImpl;

--- a/src/main/java/com/sparta/hhplusconcert/queue/usecase/CreateJWTQueueTokenService.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/usecase/CreateJWTQueueTokenService.java
@@ -1,10 +1,10 @@
-package com.sparta.hhplusconcert.usecase.queue;
+package com.sparta.hhplusconcert.queue.usecase;
 
 
 import com.sparta.hhplusconcert.domain.common.Status;
-import com.sparta.hhplusconcert.domain.queue.QueueTokenScheduler;
-import com.sparta.hhplusconcert.domain.queue.entity.QueueTokenEntity;
-import com.sparta.hhplusconcert.infra.queue.QueueTokenRepositoryImpl;
+import com.sparta.hhplusconcert.queue.domain.QueueTokenScheduler;
+import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
+import com.sparta.hhplusconcert.queue.infra.QueueTokenRepositoryImpl;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;

--- a/src/main/java/com/sparta/hhplusconcert/queue/usecase/GetRemainingQueueService.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/usecase/GetRemainingQueueService.java
@@ -1,10 +1,10 @@
-package com.sparta.hhplusconcert.usecase.queue;
+package com.sparta.hhplusconcert.queue.usecase;
 
 import com.sparta.hhplusconcert.domain.common.Status;
-import com.sparta.hhplusconcert.domain.queue.ExpiredTokenException;
-import com.sparta.hhplusconcert.domain.queue.InvalidTokenException;
-import com.sparta.hhplusconcert.domain.queue.entity.QueueTokenEntity;
-import com.sparta.hhplusconcert.infra.queue.QueueTokenRepositoryImpl;
+import com.sparta.hhplusconcert.queue.domain.ExpiredTokenException;
+import com.sparta.hhplusconcert.queue.domain.InvalidTokenException;
+import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
+import com.sparta.hhplusconcert.queue.infra.QueueTokenRepositoryImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/sparta/hhplusconcert/queue/usecase/GetRemainingQueueService.java
+++ b/src/main/java/com/sparta/hhplusconcert/queue/usecase/GetRemainingQueueService.java
@@ -1,6 +1,6 @@
 package com.sparta.hhplusconcert.queue.usecase;
 
-import com.sparta.hhplusconcert.domain.common.Status;
+import com.sparta.hhplusconcert.queue.domain.Status;
 import com.sparta.hhplusconcert.queue.domain.ExpiredTokenException;
 import com.sparta.hhplusconcert.queue.domain.InvalidTokenException;
 import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;

--- a/src/main/java/com/sparta/hhplusconcert/usecase/point/PaySeatService.java
+++ b/src/main/java/com/sparta/hhplusconcert/usecase/point/PaySeatService.java
@@ -1,15 +1,15 @@
 package com.sparta.hhplusconcert.usecase.point;
 
-import com.sparta.hhplusconcert.domain.concert.ReservationStatus;
-import com.sparta.hhplusconcert.domain.concert.SeatStatus;
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertReservationEntity;
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertSeatEntity;
+import com.sparta.hhplusconcert.concert.domain.ReservationStatus;
+import com.sparta.hhplusconcert.concert.domain.SeatStatus;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertReservationEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertSeatEntity;
 import com.sparta.hhplusconcert.domain.point.PointTransactionType;
 import com.sparta.hhplusconcert.domain.point.entity.PaymentEntity;
 import com.sparta.hhplusconcert.domain.point.entity.PointHistoryEntity;
 import com.sparta.hhplusconcert.domain.point.entity.UserEntity;
-import com.sparta.hhplusconcert.infra.concert.ConcertReservationRepositoryImpl;
-import com.sparta.hhplusconcert.infra.concert.ConcertSeatRepositoryImpl;
+import com.sparta.hhplusconcert.concert.infra.ConcertReservationRepositoryImpl;
+import com.sparta.hhplusconcert.concert.infra.ConcertSeatRepositoryImpl;
 import com.sparta.hhplusconcert.infra.point.PaymentRepositoryImpl;
 import com.sparta.hhplusconcert.infra.point.PointHistoryRepositoryImpl;
 import com.sparta.hhplusconcert.infra.point.UserRepositoryImpl;

--- a/src/test/java/com/sparta/hhplusconcert/concert/domain/ConcertSchedulerTest.java
+++ b/src/test/java/com/sparta/hhplusconcert/concert/domain/ConcertSchedulerTest.java
@@ -1,16 +1,14 @@
-package com.sparta.hhplusconcert.domain.concert;
-
-import static org.junit.jupiter.api.Assertions.*;
+package com.sparta.hhplusconcert.concert.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertReservationEntity;
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertSeatEntity;
-import com.sparta.hhplusconcert.infra.concert.ConcertReservationRepositoryImpl;
-import com.sparta.hhplusconcert.infra.concert.ConcertSeatRepositoryImpl;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertReservationEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertSeatEntity;
+import com.sparta.hhplusconcert.concert.infra.ConcertReservationRepositoryImpl;
+import com.sparta.hhplusconcert.concert.infra.ConcertSeatRepositoryImpl;
 import java.time.LocalDateTime;
 import java.util.List;
 

--- a/src/test/java/com/sparta/hhplusconcert/concert/usecase/GetConcertSchedulesServiceTest.java
+++ b/src/test/java/com/sparta/hhplusconcert/concert/usecase/GetConcertSchedulesServiceTest.java
@@ -1,14 +1,13 @@
-package com.sparta.hhplusconcert.usecase.concert;
+package com.sparta.hhplusconcert.concert.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertScheduleEntity;
-import com.sparta.hhplusconcert.infra.concert.ConcertScheduleRepositoryImpl;
-import com.sparta.hhplusconcert.usecase.concert.GetConcertSchedulesService.Output;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertScheduleEntity;
+import com.sparta.hhplusconcert.concert.infra.ConcertScheduleRepositoryImpl;
+import com.sparta.hhplusconcert.concert.usecase.GetConcertSchedulesService.Output;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
@@ -65,12 +64,12 @@ public class GetConcertSchedulesServiceTest {
     assertThat(result).hasSize(2);
 
     assertThat(result.get(0).getScheduleId()).isEqualTo(1L);
-    assertThat(result.get(0).getDate()).isEqualTo(LocalDate.of(2024, 1, 1));
+    assertThat(result.get(0).getSchedule()).isEqualTo(LocalDate.of(2024, 1, 1));
     assertThat(result.get(0).getSeatCapacity()).isEqualTo(50);
     assertThat(result.get(0).getSeatLeft()).isEqualTo(20);
 
     assertThat(result.get(1).getScheduleId()).isEqualTo(2L);
-    assertThat(result.get(1).getDate()).isEqualTo(LocalDate.of(2024, 1, 2));
+    assertThat(result.get(1).getSchedule()).isEqualTo(LocalDate.of(2024, 1, 2));
     assertThat(result.get(1).getSeatCapacity()).isEqualTo(50);
     assertThat(result.get(1).getSeatLeft()).isEqualTo(30);
 

--- a/src/test/java/com/sparta/hhplusconcert/concert/usecase/GetConcertSeatsServiceTest.java
+++ b/src/test/java/com/sparta/hhplusconcert/concert/usecase/GetConcertSeatsServiceTest.java
@@ -1,14 +1,13 @@
-package com.sparta.hhplusconcert.usecase.concert;
+package com.sparta.hhplusconcert.concert.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.sparta.hhplusconcert.domain.concert.SeatStatus;
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertSeatEntity;
-import com.sparta.hhplusconcert.infra.concert.ConcertSeatRepositoryImpl;
+import com.sparta.hhplusconcert.concert.domain.SeatStatus;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertSeatEntity;
+import com.sparta.hhplusconcert.concert.infra.ConcertSeatRepositoryImpl;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/sparta/hhplusconcert/concert/usecase/ReserveSeatServiceTest.java
+++ b/src/test/java/com/sparta/hhplusconcert/concert/usecase/ReserveSeatServiceTest.java
@@ -1,14 +1,14 @@
-package com.sparta.hhplusconcert.usecase.concert;
+package com.sparta.hhplusconcert.concert.usecase;
 
 import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.*;
 
-import com.sparta.hhplusconcert.domain.concert.ReservationStatus;
-import com.sparta.hhplusconcert.domain.concert.SeatStatus;
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertReservationEntity;
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertSeatEntity;
-import com.sparta.hhplusconcert.infra.concert.ConcertReservationRepositoryImpl;
-import com.sparta.hhplusconcert.infra.concert.ConcertSeatRepositoryImpl;
+import com.sparta.hhplusconcert.concert.domain.ReservationStatus;
+import com.sparta.hhplusconcert.concert.domain.SeatStatus;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertReservationEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertSeatEntity;
+import com.sparta.hhplusconcert.concert.infra.ConcertReservationRepositoryImpl;
+import com.sparta.hhplusconcert.concert.infra.ConcertSeatRepositoryImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;

--- a/src/test/java/com/sparta/hhplusconcert/point/usecase/ChargePointServiceTest.java
+++ b/src/test/java/com/sparta/hhplusconcert/point/usecase/ChargePointServiceTest.java
@@ -1,11 +1,9 @@
-package com.sparta.hhplusconcert.usecase.point;
+package com.sparta.hhplusconcert.point.usecase;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import com.sparta.hhplusconcert.domain.point.entity.PointHistoryEntity;
-import com.sparta.hhplusconcert.domain.point.entity.UserEntity;
-import com.sparta.hhplusconcert.infra.point.PointHistoryRepositoryImpl;
-import com.sparta.hhplusconcert.infra.point.UserRepositoryImpl;
+import com.sparta.hhplusconcert.point.domain.entity.PointHistoryEntity;
+import com.sparta.hhplusconcert.point.domain.entity.UserEntity;
+import com.sparta.hhplusconcert.point.infra.PointHistoryRepositoryImpl;
+import com.sparta.hhplusconcert.point.infra.UserRepositoryImpl;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/sparta/hhplusconcert/point/usecase/GetPointServiceTest.java
+++ b/src/test/java/com/sparta/hhplusconcert/point/usecase/GetPointServiceTest.java
@@ -1,9 +1,9 @@
-package com.sparta.hhplusconcert.usecase.point;
+package com.sparta.hhplusconcert.point.usecase;
 
 import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.sparta.hhplusconcert.infra.point.UserRepositoryImpl;
+import com.sparta.hhplusconcert.point.infra.UserRepositoryImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;

--- a/src/test/java/com/sparta/hhplusconcert/point/usecase/PaySeatServiceTest.java
+++ b/src/test/java/com/sparta/hhplusconcert/point/usecase/PaySeatServiceTest.java
@@ -1,22 +1,22 @@
-package com.sparta.hhplusconcert.usecase.point;
+package com.sparta.hhplusconcert.point.usecase;
 
 import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.sparta.hhplusconcert.domain.concert.ReservationStatus;
-import com.sparta.hhplusconcert.domain.concert.SeatStatus;
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertReservationEntity;
-import com.sparta.hhplusconcert.domain.concert.entity.ConcertSeatEntity;
-import com.sparta.hhplusconcert.domain.point.PointTransactionType;
-import com.sparta.hhplusconcert.domain.point.entity.PaymentEntity;
-import com.sparta.hhplusconcert.domain.point.entity.PointHistoryEntity;
-import com.sparta.hhplusconcert.domain.point.entity.UserEntity;
-import com.sparta.hhplusconcert.infra.concert.ConcertReservationRepositoryImpl;
-import com.sparta.hhplusconcert.infra.concert.ConcertSeatRepositoryImpl;
-import com.sparta.hhplusconcert.infra.point.PaymentRepositoryImpl;
-import com.sparta.hhplusconcert.infra.point.PointHistoryRepositoryImpl;
-import com.sparta.hhplusconcert.infra.point.UserRepositoryImpl;
+import com.sparta.hhplusconcert.concert.domain.ReservationStatus;
+import com.sparta.hhplusconcert.concert.domain.SeatStatus;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertReservationEntity;
+import com.sparta.hhplusconcert.concert.domain.entity.ConcertSeatEntity;
+import com.sparta.hhplusconcert.point.domain.PointTransactionType;
+import com.sparta.hhplusconcert.point.domain.entity.PaymentEntity;
+import com.sparta.hhplusconcert.point.domain.entity.PointHistoryEntity;
+import com.sparta.hhplusconcert.point.domain.entity.UserEntity;
+import com.sparta.hhplusconcert.concert.infra.ConcertReservationRepositoryImpl;
+import com.sparta.hhplusconcert.concert.infra.ConcertSeatRepositoryImpl;
+import com.sparta.hhplusconcert.point.infra.PaymentRepositoryImpl;
+import com.sparta.hhplusconcert.point.infra.PointHistoryRepositoryImpl;
+import com.sparta.hhplusconcert.point.infra.UserRepositoryImpl;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/sparta/hhplusconcert/queue/domain/QueueTokenSchedulerTest.java
+++ b/src/test/java/com/sparta/hhplusconcert/queue/domain/QueueTokenSchedulerTest.java
@@ -1,14 +1,12 @@
-package com.sparta.hhplusconcert.domain.queue;
+package com.sparta.hhplusconcert.queue.domain;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import com.sparta.hhplusconcert.domain.common.Status;
-import com.sparta.hhplusconcert.domain.queue.entity.QueueTokenEntity;
-import com.sparta.hhplusconcert.infra.queue.QueueTokenRepositoryImpl;
+import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
+import com.sparta.hhplusconcert.queue.infra.QueueTokenRepositoryImpl;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -76,9 +74,10 @@ public class QueueTokenSchedulerTest {
   @Test
   void expireQueueToken_whenExpiredTokensPresent_shouldUpdateToExpired() {
     // Given
-    QueueTokenEntity expiredToken = QueueTokenEntity.builder().id(1L).build();
+    LocalDateTime issuedTime = LocalDateTime.now();
+    QueueTokenEntity expiredToken = QueueTokenEntity.builder().id(1L).issuedTime(issuedTime).build();
     expiredToken.setStatus(Status.WAITING);
-    when(queueTokenRepository.getExpiredQueueTokens(LocalDateTime.now()))
+    when(queueTokenRepository.getExpiredQueueTokens(issuedTime))
         .thenReturn(List.of(expiredToken));
 
     // When

--- a/src/test/java/com/sparta/hhplusconcert/queue/usecase/CreateJWTQueueTokenServiceTest.java
+++ b/src/test/java/com/sparta/hhplusconcert/queue/usecase/CreateJWTQueueTokenServiceTest.java
@@ -1,9 +1,7 @@
-package com.sparta.hhplusconcert.usecase.queue;
+package com.sparta.hhplusconcert.queue.usecase;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import com.sparta.hhplusconcert.domain.queue.entity.QueueTokenEntity;
-import com.sparta.hhplusconcert.infra.queue.QueueTokenRepositoryImpl;
+import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
+import com.sparta.hhplusconcert.queue.infra.QueueTokenRepositoryImpl;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import jakarta.xml.bind.DatatypeConverter;

--- a/src/test/java/com/sparta/hhplusconcert/queue/usecase/GetRemainingQueueServiceTest.java
+++ b/src/test/java/com/sparta/hhplusconcert/queue/usecase/GetRemainingQueueServiceTest.java
@@ -1,8 +1,8 @@
-package com.sparta.hhplusconcert.usecase.queue;
+package com.sparta.hhplusconcert.queue.usecase;
 
-import com.sparta.hhplusconcert.domain.common.Status;
-import com.sparta.hhplusconcert.domain.queue.entity.QueueTokenEntity;
-import com.sparta.hhplusconcert.infra.queue.QueueTokenRepositoryImpl;
+import com.sparta.hhplusconcert.queue.domain.Status;
+import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
+import com.sparta.hhplusconcert.queue.infra.QueueTokenRepositoryImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;

--- a/src/test/java/com/sparta/hhplusconcert/queue/usecase/TokenValidatorTest.java
+++ b/src/test/java/com/sparta/hhplusconcert/queue/usecase/TokenValidatorTest.java
@@ -1,9 +1,9 @@
-package com.sparta.hhplusconcert.usecase.queue;
+package com.sparta.hhplusconcert.queue.usecase;
 
-import com.sparta.hhplusconcert.domain.common.Status;
-import com.sparta.hhplusconcert.domain.queue.TokenValidator;
-import com.sparta.hhplusconcert.domain.queue.entity.QueueTokenEntity;
-import com.sparta.hhplusconcert.infra.queue.QueueTokenRepositoryImpl;
+import com.sparta.hhplusconcert.queue.domain.Status;
+import com.sparta.hhplusconcert.queue.domain.TokenValidator;
+import com.sparta.hhplusconcert.queue.domain.entity.QueueTokenEntity;
+import com.sparta.hhplusconcert.queue.infra.QueueTokenRepositoryImpl;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
## 작업 내역
- 패키지구조를 `계층/도메인` -> `도메인/계층` 으로 변경하였습니다.

```
<도메인>/ (concert, point, queue, config...)
  api/
    controller/
    request/
    response/
  usecase/
  domain/
    entity/
  infra/
```